### PR TITLE
Feature/spielerkonto

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build_cmds
+.vscode
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 build_cmds
 .vscode
-
+bin/

--- a/Akzeptanztest.md
+++ b/Akzeptanztest.md
@@ -1,0 +1,9 @@
+# Akzeptanztest - Spielerkonto
+
+|                   Aktion                       | Erwartetes Ergebnis | Erfolgreich |
+|----|---|---|
+| Es wird sich auf dem selben Computer 2. mal eingeloggt  |  Die Verbindung zum 2. Client wird geschlossen | ✓ |
+| Client loggt sich zu einem späteren erneut an | Verbindung wird aufgebaut und der Spieler erhält seine letzte Kartenreihenfolge  | ✓ |
+
+
+

--- a/bin/.gitignore
+++ b/bin/.gitignore
@@ -1,5 +1,0 @@
-/allgemein/
-/client/
-/common/
-/messages/
-/server/

--- a/src/client/YoolooClient.java
+++ b/src/client/YoolooClient.java
@@ -64,6 +64,11 @@ public class YoolooClient {
 				failedOnce = true;	
 			}
 
+			System.out.println("Bitte gebe die Server IP/Hostname ein:");
+			System.out.print(">> ");
+			this.serverHostname = temporary.nextLine();
+
+
 			System.out.println("Logge als " + this.spielerName + " ein");
 
 			temporary.close();
@@ -230,6 +235,9 @@ public class YoolooClient {
 	private LoginMessage eingabeSpielerDatenFuerLogin() {
 		// TODO Spielername, GameMode und ggfs mehr ermitteln
 		return null;
+	}
+	public String getDisplayName() {
+		return this.spielerName;
 	}
 
 	public void ausgabeKartenSet() {

--- a/src/client/YoolooClient.java
+++ b/src/client/YoolooClient.java
@@ -30,7 +30,7 @@ public class YoolooClient {
 
 	private ClientState clientState = ClientState.CLIENTSTATE_NULL;
 
-	private String spielerName = "";
+	private String spielername = "";
 	private LoginMessage newLogin = null;
 	private YoolooSpieler meinSpieler;
 	private YoolooStich[] spielVerlauf = null;
@@ -53,15 +53,15 @@ public class YoolooClient {
 
 		try {
 			// Lese Namen aus stdin //
-			boolean failedOnce = false;
+			boolean nameNotLongEnough = false;
 			System.out.println("Bitte gebe zunächst deinen Namen an:");
 			Scanner temporary = new Scanner(System.in);
 			
-			while(this.spielerName.length() < 4){
-				if(failedOnce) System.out.println("Dein Name muss mindestens 4 Zeichen lang sein.");
+			while(this.spielername.length() < 4){
+				if(nameNotLongEnough) System.out.println("Dein Name muss mindestens 4 Zeichen lang sein.");
 				System.out.print(">> "); 
-				this.spielerName = temporary.nextLine();
-				failedOnce = true;	
+				this.spielername = temporary.nextLine();
+				nameNotLongEnough = true;	
 			}
 
 			System.out.println("Bitte gebe die Server IP/Hostname ein:");
@@ -69,7 +69,7 @@ public class YoolooClient {
 			this.serverHostname = temporary.nextLine();
 
 
-			System.out.println("Logge als " + this.spielerName + " ein");
+			System.out.println("Logge als " + this.spielername + " ein");
 
 			temporary.close();
 			//////////////////////////
@@ -92,55 +92,55 @@ public class YoolooClient {
 				}
 				// 3. Schritt Kommandospezifisch reagieren
 				switch (kommandoMessage.getServerMessageType()) {
-				case SERVERMESSAGE_SENDLOGIN:
-					// Server fordert Useridentifikation an
-					// Falls User local noch nicht bekannt wird er bestimmt
-					/*
-					if (newLogin == null || clientState == ClientState.CLIENTSTATE_LOGIN) {
-						// Spielerdaten vom Server ermitteln
+					case SERVERMESSAGE_SENDLOGIN:
+						// Server fordert Useridentifikation an
+						// Falls User local noch nicht bekannt wird er bestimmt
+						/*
+						if (newLogin == null || clientState == ClientState.CLIENTSTATE_LOGIN) {
+							// Spielerdaten vom Server ermitteln
 
-						newLogin = eingabeSpielerDatenFuerLogin(); //Dummy aufruf
-						newLogin = new LoginMessage(spielerName);
-					}*/
-					// Client meldet den Spieler an den Server
-					newLogin = new LoginMessage(spielerName);
-					System.out.println("Sende LoginMessage an Server");
-					oos.writeObject(newLogin);
-					empfangeSpieler();
+							newLogin = eingabeSpielerDatenFuerLogin(); //Dummy aufruf
+							newLogin = new LoginMessage(spielername);
+						}*/
+						// Client meldet den Spieler an den Server
+						newLogin = new LoginMessage(spielername);
+						
+						oos.writeObject(newLogin);
+						empfangeSpieler();
 
-					/*
-					oos.writeObject(newLogin);
-					System.out.println("[id-x]ClientStatus: " + clientState + "] : LoginMessage fuer  " + spielerName
-							+ " an server gesendet warte auf Spielerdaten");
-					empfangeSpieler();
-					// ausgabeKartenSet();
-					*/
-					break;
-				case SERVERMESSAGE_SORT_CARD_SET:
-					// sortieren Karten
-					meinSpieler.sortierungFestlegen();
-					ausgabeKartenSet();
-					// ggfs. Spielverlauf lรถschen
-					spielVerlauf = new YoolooStich[YoolooKartenspiel.maxKartenWert];
-					ClientMessage message = new ClientMessage(ClientMessageType.ClientMessage_OK,
-							"Kartensortierung ist erfolgt!");
-					oos.writeObject(message);
-					break;
-				case SERVERMESSAGE_SEND_CARD:
-					spieleStich(kommandoMessage.getParamInt());
-					break;
-				case SERVERMESSAGE_RESULT_SET:
-					System.out.println("[id-" + meinSpieler.getClientHandlerId() + "]ClientStatus: " + clientState
-							+ "] : Ergebnis ausgeben ");
-					String ergebnis = empfangeErgebnis();
-					System.out.println(ergebnis.toString());
-					break;
-					           // basic version: wechsel zu ClientState Disconnected thread beenden
-				case SERVERMESSAGE_CHANGE_STATE:
-				break ;
-				
-				default:
-					break;
+						/*
+						oos.writeObject(newLogin);
+						System.out.println("[id-x]ClientStatus: " + clientState + "] : LoginMessage fuer  " + spielername
+								+ " an server gesendet warte auf Spielerdaten");
+						empfangeSpieler();
+						// ausgabeKartenSet();
+						*/
+						break;
+					case SERVERMESSAGE_SORT_CARD_SET:
+						// sortieren Karten
+						meinSpieler.sortierungFestlegen();
+						ausgabeKartenSet();
+						// ggfs. Spielverlauf lรถschen
+						spielVerlauf = new YoolooStich[YoolooKartenspiel.maxKartenWert];
+						ClientMessage message = new ClientMessage(ClientMessageType.ClientMessage_OK,
+								"Kartensortierung ist erfolgt!");
+						oos.writeObject(message);
+						break;
+					case SERVERMESSAGE_SEND_CARD:
+						spieleStich(kommandoMessage.getParamInt());
+						break;
+					case SERVERMESSAGE_RESULT_SET:
+						System.out.println("[id-" + meinSpieler.getClientHandlerId() + "]ClientStatus: " + clientState
+								+ "] : Ergebnis ausgeben ");
+						String ergebnis = empfangeErgebnis();
+						System.out.println(ergebnis.toString());
+						break;
+								// basic version: wechsel zu ClientState Disconnected thread beenden
+					case SERVERMESSAGE_CHANGE_STATE:
+					break ;
+					
+					default:
+						break;
 				}
 			}
 		} catch (UnknownHostException e) {
@@ -241,11 +241,11 @@ public class YoolooClient {
 	}
 
 	private LoginMessage eingabeSpielerDatenFuerLogin() {
-		// TODO Spielername, GameMode und ggfs mehr ermitteln
+		// TODO spielername, GameMode und ggfs mehr ermitteln
 		return null;
 	}
 	public String getDisplayName() {
-		return this.spielerName;
+		return this.spielername;
 	}
 
 	public void ausgabeKartenSet() {

--- a/src/client/YoolooClient.java
+++ b/src/client/YoolooClient.java
@@ -95,18 +95,26 @@ public class YoolooClient {
 				case SERVERMESSAGE_SENDLOGIN:
 					// Server fordert Useridentifikation an
 					// Falls User local noch nicht bekannt wird er bestimmt
+					/*
 					if (newLogin == null || clientState == ClientState.CLIENTSTATE_LOGIN) {
 						// Spielerdaten vom Server ermitteln
 
 						newLogin = eingabeSpielerDatenFuerLogin(); //Dummy aufruf
 						newLogin = new LoginMessage(spielerName);
-					}
+					}*/
 					// Client meldet den Spieler an den Server
+					newLogin = new LoginMessage(spielerName);
+					System.out.println("Sende LoginMessage an Server");
+					oos.writeObject(newLogin);
+					empfangeSpieler();
+
+					/*
 					oos.writeObject(newLogin);
 					System.out.println("[id-x]ClientStatus: " + clientState + "] : LoginMessage fuer  " + spielerName
 							+ " an server gesendet warte auf Spielerdaten");
 					empfangeSpieler();
 					// ausgabeKartenSet();
+					*/
 					break;
 				case SERVERMESSAGE_SORT_CARD_SET:
 					// sortieren Karten
@@ -169,9 +177,9 @@ public class YoolooClient {
 	}
 
 	private void spieleStich(int stichNummer) throws IOException {
-		System.out.println("[id-" + meinSpieler.getClientHandlerId() + "]ClientStatus: " + clientState
-				+ "] : Spiele Karte " + stichNummer);
+		System.out.println("-> Spiele Karte " + stichNummer);
 		spieleKarteAus(stichNummer);
+		System.out.println("-> Karte ausgespielt, empfange Stich");
 		YoolooStich iStich = empfangeStich();
 		spielVerlauf[stichNummer] = iStich;
 		System.out.println("[id-" + meinSpieler.getClientHandlerId() + "]ClientStatus: " + clientState

--- a/src/client/YoolooClient.java
+++ b/src/client/YoolooClient.java
@@ -76,6 +76,10 @@ public class YoolooClient {
 				// 1. Schritt Kommado empfangen
 				ServerMessage kommandoMessage = empfangeKommando();
 				System.out.println("[id-x]ClientStatus: " + clientState + "] " + kommandoMessage.toString());
+				if(kommandoMessage.getServerMessageType() == ServerMessage.ServerMessageType.SERVERMESSAGE_ALREADY_LOGGED_IN){
+					System.out.println("Du bist bereits eingeloggt!");
+					System.exit(0);
+				}
 				// 2. Schritt ClientState ggfs aktualisieren (fuer alle neuen Kommandos)
 				ClientState newClientState = kommandoMessage.getNextClientState();
 				if (newClientState != null) {
@@ -87,8 +91,8 @@ public class YoolooClient {
 					// Server fordert Useridentifikation an
 					// Falls User local noch nicht bekannt wird er bestimmt
 					if (newLogin == null || clientState == ClientState.CLIENTSTATE_LOGIN) {
-						// TODO Klasse LoginMessage erweiteren um Interaktives ermitteln des
-						// Spielernames, GameModes, ...)
+						// Spielerdaten vom Server ermitteln
+
 						newLogin = eingabeSpielerDatenFuerLogin(); //Dummy aufruf
 						newLogin = new LoginMessage(spielerName);
 					}

--- a/src/client/YoolooClient.java
+++ b/src/client/YoolooClient.java
@@ -7,6 +7,7 @@ package client;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.util.Scanner;
 import java.net.ConnectException;
 import java.net.Socket;
 import java.net.UnknownHostException;
@@ -29,7 +30,7 @@ public class YoolooClient {
 
 	private ClientState clientState = ClientState.CLIENTSTATE_NULL;
 
-	private String spielerName = "Name" + (System.currentTimeMillis() + "").substring(6);
+	private String spielerName = "";
 	private LoginMessage newLogin = null;
 	private YoolooSpieler meinSpieler;
 	private YoolooStich[] spielVerlauf = null;
@@ -51,6 +52,23 @@ public class YoolooClient {
 	public void startClient() {
 
 		try {
+			// Lese Namen aus stdin //
+			boolean failedOnce = false;
+			System.out.println("Bitte gebe zunächst deinen Namen an:");
+			Scanner temporary = new Scanner(System.in);
+			
+			while(this.spielerName.length() < 4){
+				if(failedOnce) System.out.println("Dein Name muss mindestens 4 Zeichen lang sein.");
+				System.out.print(">> "); 
+				this.spielerName = temporary.nextLine();
+				failedOnce = true;	
+			}
+
+			System.out.println("Logge als " + this.spielerName + " ein");
+
+			temporary.close();
+			//////////////////////////
+
 			clientState = ClientState.CLIENTSTATE_CONNECT;
 			verbindeZumServer();
 
@@ -85,7 +103,7 @@ public class YoolooClient {
 					// sortieren Karten
 					meinSpieler.sortierungFestlegen();
 					ausgabeKartenSet();
-					// ggfs. Spielverlauf löschen
+					// ggfs. Spielverlauf lรถschen
 					spielVerlauf = new YoolooStich[YoolooKartenspiel.maxKartenWert];
 					ClientMessage message = new ClientMessage(ClientMessageType.ClientMessage_OK,
 							"Kartensortierung ist erfolgt!");

--- a/src/common/YoolooKartenspiel.java
+++ b/src/common/YoolooKartenspiel.java
@@ -85,11 +85,17 @@ public class YoolooKartenspiel {
 		Kartenfarbe[] farben = Kartenfarbe.values();
 		neuerSpieler.setSpielfarbe(farben[neuerSpieler.getClientHandlerId()]);
 
-		if(cardList.size() )
-		YoolooKarte[] Karten = new YoolooKarte[cardList.size()];
-		for(int i = 0; i < Karten.length; i++) {
-			Karten[i] = new YoolooKarte(farben[neuerSpieler.getClientHandlerId()], cardList.get(i));
+		YoolooKarte[] Karten = new YoolooKarte[10];
+		if(cardList.size() > 0){
+			for(int i = 0; i < Karten.length; i++) {
+				Karten[i] = new YoolooKarte(farben[neuerSpieler.getClientHandlerId()], cardList.get(i));
+			}			
+		}else{
+			/*   Benutzer hatte bis dato noch nie gespielt.   */
+			Karten = spielkarten[neuerSpieler.getClientHandlerId()];
 		}
+
+
 		neuerSpieler.setAktuelleSortierung(Karten);
 		this.spielerliste.add(neuerSpieler); // nur fuer Simulation noetig!
 		System.out.println("Debug; Spielerobject registriert als : " + neuerSpieler);

--- a/src/common/YoolooKartenspiel.java
+++ b/src/common/YoolooKartenspiel.java
@@ -81,11 +81,16 @@ public class YoolooKartenspiel {
 	 * @param spielerName
 	 * @return
 	 */
-	public YoolooSpieler spielerRegistrieren(YoolooSpieler neuerSpieler) {
+	public YoolooSpieler spielerRegistrieren(YoolooSpieler neuerSpieler, ArrayList<Integer> cardList) {
 		Kartenfarbe[] farben = Kartenfarbe.values();
 		neuerSpieler.setSpielfarbe(farben[neuerSpieler.getClientHandlerId()]);
-		YoolooKarte[] kartenDesSpielers = spielkarten[neuerSpieler.getClientHandlerId()];
-		neuerSpieler.setAktuelleSortierung(kartenDesSpielers);
+
+		if(cardList.size() )
+		YoolooKarte[] Karten = new YoolooKarte[cardList.size()];
+		for(int i = 0; i < Karten.length; i++) {
+			Karten[i] = new YoolooKarte(farben[neuerSpieler.getClientHandlerId()], cardList.get(i));
+		}
+		neuerSpieler.setAktuelleSortierung(Karten);
 		this.spielerliste.add(neuerSpieler); // nur fuer Simulation noetig!
 		System.out.println("Debug; Spielerobject registriert als : " + neuerSpieler);
 		return neuerSpieler;

--- a/src/messages/ServerMessage.java
+++ b/src/messages/ServerMessage.java
@@ -31,6 +31,7 @@ public class ServerMessage implements Serializable {
 	 */
 	public enum ServerMessageType {
 		SERVERMESSAGE_ACKNOWLEDGE, // t.b.d.
+		SERVERMESSAGE_ALREADY_LOGGED_IN, // Wird gesendet, wenn der Client bereits eingeloggt ist
 		SERVERMESSAGE_SENDLOGIN, // Übermittle registierten Spieler zurueck an Client
 		SERVERMESSAGE_SORT_CARD_SET, // Spieler legen Ihre Sortierung fest
 		SERVERMESSAGE_SEND_CARD, // Karten werden an Spieler ausgegeben

--- a/src/server/YoolooClientHandler.java
+++ b/src/server/YoolooClientHandler.java
@@ -102,14 +102,14 @@ public class YoolooClientHandler extends Thread {
 					switch (session.getGamemode()) {
 					case GAMEMODE_SINGLE_GAME:
 						// Triggersequenz zur Abfrage der einzelnen Karten des Spielers
-						ArrayList<YoolooKarte> Karten = new ArrayList<YoolooKarte>();
+						ArrayList<Integer> Karten = new ArrayList<Integer>();
 						for (int stichNummer = 0; stichNummer < YoolooKartenspiel.maxKartenWert; stichNummer++) {
 							sendeKommando(ServerMessageType.SERVERMESSAGE_SEND_CARD,
 									ClientState.CLIENTSTATE_PLAY_SINGLE_GAME, null, stichNummer);
 							// Neue YoolooKarte in Session ausspielen und Stich abfragen
 							YoolooKarte neueKarte = (YoolooKarte) empfangeVomClient();
 							System.out.println("[ClientHandler" + clientHandlerId + "] Karte empfangen:" + neueKarte);
-							Karten.add(neueKarte);
+							Karten.add(neueKarte.getWert());
 							YoolooStich currentstich = spieleKarte(stichNummer, neueKarte);
 							// Punkte fuer gespielten Stich ermitteln
 							if (currentstich.getSpielerNummer() == clientHandlerId) {
@@ -196,9 +196,10 @@ public class YoolooClientHandler extends Thread {
 	}
 
 	private void registriereSpielerInSession(YoolooSpieler meinSpieler) {
-		System.out
-				.println("[ClientHandler" + clientHandlerId + "] registriereSpielerInSession " + meinSpieler.getName());
-		session.getAktuellesSpiel().spielerRegistrieren(meinSpieler);
+		System.out.println("[ClientHandler" + clientHandlerId + "] registriereSpielerInSession " + meinSpieler.getName());
+		ArrayList<Integer> KartenReihenfolge = this.myServer.getCardOrder(this.meinSpieler.getName());
+
+		session.getAktuellesSpiel().spielerRegistrieren(meinSpieler, KartenReihenfolge);
 	}
 
 	/**

--- a/src/server/YoolooClientHandler.java
+++ b/src/server/YoolooClientHandler.java
@@ -12,6 +12,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.net.Socket;
 import java.net.SocketAddress;
+import java.util.ArrayList;
 
 import client.YoolooClient.ClientState;
 import common.LoginMessage;
@@ -101,12 +102,14 @@ public class YoolooClientHandler extends Thread {
 					switch (session.getGamemode()) {
 					case GAMEMODE_SINGLE_GAME:
 						// Triggersequenz zur Abfrage der einzelnen Karten des Spielers
+						ArrayList<YoolooKarte> Karten = new ArrayList<YoolooKarte>();
 						for (int stichNummer = 0; stichNummer < YoolooKartenspiel.maxKartenWert; stichNummer++) {
 							sendeKommando(ServerMessageType.SERVERMESSAGE_SEND_CARD,
 									ClientState.CLIENTSTATE_PLAY_SINGLE_GAME, null, stichNummer);
 							// Neue YoolooKarte in Session ausspielen und Stich abfragen
 							YoolooKarte neueKarte = (YoolooKarte) empfangeVomClient();
 							System.out.println("[ClientHandler" + clientHandlerId + "] Karte empfangen:" + neueKarte);
+							Karten.add(neueKarte);
 							YoolooStich currentstich = spieleKarte(stichNummer, neueKarte);
 							// Punkte fuer gespielten Stich ermitteln
 							if (currentstich.getSpielerNummer() == clientHandlerId) {
@@ -117,6 +120,10 @@ public class YoolooClientHandler extends Thread {
 							// Stich an Client uebermitteln
 							oos.writeObject(currentstich);
 						}
+						/*   Kartenfolge speichern   */
+						this.myServer.saveCardOrder(Karten, this.meinSpieler.getName());
+
+
 						this.state = ServerState.ServerState_DISCONNECT;
 						break;
 					default:

--- a/src/server/YoolooServer.java
+++ b/src/server/YoolooServer.java
@@ -39,7 +39,7 @@ public class YoolooServer {
 	private boolean serverAktiv = true;
 	private LinkedHashMap<String, ArrayList<Integer>> cardMap = new LinkedHashMap<>();
 
-	// private LinkedHashMap<Thread> spielerThreads;
+	
 	private LinkedHashMap<String, YoolooClientHandler> clientHandlerList;
 
 	private ExecutorService spielerPool;

--- a/src/server/YoolooServer.java
+++ b/src/server/YoolooServer.java
@@ -9,6 +9,7 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.InetSocketAddress;
 import java.util.LinkedHashMap;
+import java.util.ArrayList;
 import java.util.Map.Entry;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -16,6 +17,7 @@ import java.util.concurrent.Executors;
 import common.YoolooKartenspiel;
 import messages.ServerMessage;
 import client.YoolooClient;
+import common.YoolooKarte;
 import utils.socketutils;
 
 public class YoolooServer {
@@ -35,6 +37,7 @@ public class YoolooServer {
 
 	private ServerSocket serverSocket = null;
 	private boolean serverAktiv = true;
+	private LinkedHashMap<String, ArrayList<YoolooKarte>> cardMap;
 
 	// private LinkedHashMap<Thread> spielerThreads;
 	private LinkedHashMap<String, YoolooClientHandler> clientHandlerList;
@@ -136,5 +139,9 @@ public class YoolooServer {
 		} else {
 			System.out.println("Servercode falsch");
 		}
+	}
+	public void saveCardOrder(ArrayList<YoolooKarte> order, String clientName) {
+		System.out.println("[~] Speichere Kartenabfolge für " + clientName);
+		cardMap.put(clientName, order);
 	}
 }

--- a/src/server/YoolooServer.java
+++ b/src/server/YoolooServer.java
@@ -37,7 +37,7 @@ public class YoolooServer {
 
 	private ServerSocket serverSocket = null;
 	private boolean serverAktiv = true;
-	private LinkedHashMap<String, ArrayList<YoolooKarte>> cardMap;
+	private LinkedHashMap<String, ArrayList<Integer>> cardMap;
 
 	// private LinkedHashMap<Thread> spielerThreads;
 	private LinkedHashMap<String, YoolooClientHandler> clientHandlerList;
@@ -140,8 +140,16 @@ public class YoolooServer {
 			System.out.println("Servercode falsch");
 		}
 	}
-	public void saveCardOrder(ArrayList<YoolooKarte> order, String clientName) {
+	public void saveCardOrder(ArrayList<Integer> order, String clientName) {
 		System.out.println("[~] Speichere Kartenabfolge für " + clientName);
 		cardMap.put(clientName, order);
+	}
+	public ArrayList<Integer> getCardOrder(String clientName) {
+		if(this.cardMap.containsKey(clientName)){
+			System.out.println("[>] " + clientName + " ist bekannt, sende letzte Kartenreihenfolge.");
+			return this.cardMap.get(clientName);
+		}else{
+			return new ArrayList<Integer>();
+		}
 	}
 }

--- a/src/server/YoolooServer.java
+++ b/src/server/YoolooServer.java
@@ -37,7 +37,7 @@ public class YoolooServer {
 
 	private ServerSocket serverSocket = null;
 	private boolean serverAktiv = true;
-	private LinkedHashMap<String, ArrayList<Integer>> cardMap;
+	private LinkedHashMap<String, ArrayList<Integer>> cardMap = new LinkedHashMap<>();
 
 	// private LinkedHashMap<Thread> spielerThreads;
 	private LinkedHashMap<String, YoolooClientHandler> clientHandlerList;

--- a/src/utils/socketutils.java
+++ b/src/utils/socketutils.java
@@ -1,0 +1,22 @@
+package utils;
+
+import java.io.Serializable;
+import java.io.ObjectOutputStream;
+import java.io.IOException;
+import java.net.Socket;
+
+public class socketutils {
+
+    public static void sendSerialized(Socket s, Serializable object) {
+        try {
+            ObjectOutputStream oos = new ObjectOutputStream(s.getOutputStream());
+            oos.writeObject(object);
+            oos.close();
+        }catch(IOException e){
+            e.printStackTrace();
+        }
+        return;
+    }
+}
+
+


### PR DESCRIPTION
Implementierung vom **Spielerkonto** Modul

> Spieler sollten vom Server über den Namen wiedererkannt werden (eindeutige
Identifikation) Die zuletzt gespielte Kartensortierung muss dann als
Ausgangslage für die neue Runde wiederhergestellt werden. Ein Spieler darf
nicht doppelt in einer Runde teilnehmen („Gegen sich selbst spielen“). 

Der Client liest beim Start den **Namen** und **IP/Hostname** aus `stdin` aus.
Beim Login speichert der Server die IP des Clients und dessen Socket in einer `LinkedHashMap<String, Socket>`, wenn der Client jetzt ein zweites mal gestartet wird, schließt der Server die Verbindung nachdem er ein `SERVERMESSAGE_ALREADY_LOGGED_IN` schickt

Die Kartenreihenfolge wird nach der Runde mit dem Benutzernamen gespeichert, und beim nächsten Login ausgelesen und als initiale Kartenreihenfolge zum Client geschickt .

Die beiden Schritte werden __nicht__ persistent gespeichert sondern sind nur zur Laufzeit im Arbeitsspeicher